### PR TITLE
Ensure pre elements use same font as other content

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -416,9 +416,11 @@ min-width: 200px;
 
 /* mandoc styles */
 
-.mandoc {
+.mandoc, .mandoc pre, .mandoc code {
     font-family: 'Inconsolata', monospace;
     font-size: 1.04rem;
+}
+.mandoc {
     margin-right: 45px;
 
     /* Required so that table.head and table.foot can take up 100% of what remains after floating the panels. */


### PR DESCRIPTION
Firefox comes with a built-in `pre` rule that would use the default
monospaced font set by the user. This rule overrides the font specified
for `.mandoc` as inherited elements never win.