### PR TITLE
assets/style.css: deemphasize panels

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -145,6 +145,7 @@ a:visited {
     margin: 0 10px 0 52px;
     display: flex;
     flex-direction: row;
+    justify-content: space-between;
 }
 
 .paneljump {
@@ -175,6 +176,7 @@ a:visited {
 .panels {
     display: block;
     order: 2;
+    font-size: smaller;
 }
 
 .maincontent {
@@ -228,7 +230,7 @@ a, a:hover, a:focus, a:visited {
 
 .panel-heading, .panel details {
   margin: -15px -15px 0px;
-  background-color: #d70751;
+  background-color: #ffffff;
   border-bottom: 1px solid #dddddd;
   border-top-right-radius: 3px;
   border-top-left-radius: 3px;
@@ -236,9 +238,7 @@ a, a:hover, a:focus, a:visited {
 
 .panel-heading, .panel summary {
   padding: 5px 5px;
-  font-size: 17.5px;
-  font-weight: 500;
-  color: #ffffff;
+  color: #000000;
   outline-style: none;
 }
 


### PR DESCRIPTION
The panels with links, table of contents, other versions/languages/sections dominate the visual appearance of the manpage display: They use graphical elements (white text on red background), a large font size, and on wide screens are located close to the center of the screen. This distracts from the actual manpage content.

With this pull request I'd like to propose a few small changes:
- move the panels to the right of screen (from right next to the manpage content)
- just use black on white panel titles
- decrease the panels' font size

What do you think?

(And while I am here: Thank you for the new manpages.debian.org service. This is absolutely fantastic.)