### PR TITLE
debiman-auxserver.service: Add Documentation key

### DIFF
--- a/debiman-auxserver.service
+++ b/debiman-auxserver.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=debiman auxiliary service endpoints
+Documentation=man:debiman-auxserver(1)
 
 [Service]
 Restart=always


### PR DESCRIPTION
The systemd service file does not contain a Documentation key. Documentation for systemd service files can be automatically viewed using systemctl help servicename if this field is present.