### PR TITLE
fix #143 by giving synonyms horizontal clearance

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -541,7 +541,7 @@ h2 {
 		padding-right: 1.2em;
 		vertical-align: top; }
 .Bl-tag > dd {
-		clear: right;
+		clear: both;
 		width: 100%;
 		margin-top: 0em;
 		margin-left: 0em;


### PR DESCRIPTION
this `clear: right` that's being replaced certainly seems to be intended
to do the same thing, but (see issue #143 screenshots):

- a. I've not been able to confirm what it actually does (perhaps it
  worked at some point, but it doesn't seem to now)
- b. I've given man pages a _cursory_ glance and I can't see any _harm_
  in having `both` (only effect is the _fix_ of 143).