### PR TITLE
s/conflicting packages/other packages/

### DIFF
--- a/assets/manpage.tmpl
+++ b/assets/manpage.tmpl
@@ -98,7 +98,7 @@ other sections
 {{ if gt (len .Bins) 1 }}
 <div class="panel" role="complementary">
 <div class="panel-heading" role="heading">
-conflicting packages
+other packages
 </div>
 <div class="panel-body">
 <ul class="list-group list-group-flush">

--- a/assets/manpageerror.tmpl
+++ b/assets/manpageerror.tmpl
@@ -98,7 +98,7 @@ other sections
 {{ if gt (len .Bins) 1 }}
 <div class="panel" role="complementary">
 <div class="panel-heading" role="heading">
-conflicting packages
+other packages
 </div>
 <div class="panel-body">
 <ul class="list-group list-group-flush">


### PR DESCRIPTION
The term "conflicting packages" is inaccurate, because with the alternatives system, multiple packages can provide the same man page without conflicting with each other.