### PR TITLE
Emit JSON-LD breadcrumbs as object, not quoted string

### DIFF
--- a/cmd/debiman/render.go
+++ b/cmd/debiman/render.go
@@ -52,7 +52,7 @@ type breadcrumb struct {
 
 type breadcrumbs []breadcrumb
 
-func (b breadcrumbs) ToJSON() template.HTML {
+func (b breadcrumbs) ToJSON() template.JS {
 	type item struct {
 		Type string `json:"@type"`
 		ID   string `json:"@id"`
@@ -88,7 +88,7 @@ func (b breadcrumbs) ToJSON() template.HTML {
 	if err != nil {
 		log.Fatal(err)
 	}
-	return template.HTML(jsonb)
+	return template.JS(jsonb)
 }
 
 var commonTmpls = commontmpl.MustParseCommonTmpls()

--- a/cmd/debiman/render_test.go
+++ b/cmd/debiman/render_test.go
@@ -25,6 +25,40 @@ func TestBreadcrumbsToJSON(t *testing.T) {
 	}
 }
 
+// Ensure that the JSON-LD breadcrumbs are emitted as a JSON object and
+// not, due to html/template's contextual escaping inside <script>, as a
+// quoted (and backslash-escaped) JSON string. See issue #193.
+func TestBreadcrumbsRenderedAsObject(t *testing.T) {
+	var buf bytes.Buffer
+	err := manpageTmpl.ExecuteTemplate(&buf, "manpage", manpagePrepData{
+		Meta: &manpage.Meta{
+			Name:    "test",
+			Section: "1",
+			Package: &manpage.PkgMeta{
+				Suite:     "testing",
+				Binarypkg: "test",
+			},
+		},
+		Breadcrumbs: breadcrumbs{
+			{"/contents-testing.html", "testing"},
+			{"", "test(1)"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, `<script type="application/ld+json">`) {
+		t.Fatal("ld+json script tag missing from output")
+	}
+	if !strings.Contains(out, `{"@context":"http://schema.org"`) {
+		t.Errorf("ld+json not emitted as a JSON object; output:\n%s", out)
+	}
+	if strings.Contains(out, `"{\"@context\"`) {
+		t.Errorf("ld+json emitted as a quoted JSON string; output:\n%s", out)
+	}
+}
+
 // Ensure that section names containing unsafe characters like colons
 // are properly handled (and do not result in ZgotmplZ values) on pages
 // like https://manpages.debian.org/trixie/foot/foot.ini.5.en.html


### PR DESCRIPTION
## Problem

The breadcrumbs JSON-LD on manpage pages was being emitted as a quoted, backslash-escaped string rather than a JSON object:

```html
<script type="application/ld+json">
"{\"@context\":\"http://schema.org\",...}"
</script>
```

This is invalid JSON-LD and prevents schema validators and search engines (Google breadcrumb parsing) from reading the `BreadcrumbList`.

## Root cause

`breadcrumbs.ToJSON()` returned `template.HTML`, but it is interpolated inside a `<script type="application/ld+json">` element in `assets/manpage.tmpl`. Go's `html/template` applies contextual auto-escaping and treats `<script>` content as a JavaScript context, where only `template.JS` is trusted. A `template.HTML` value is just an ordinary string there, so it gets JSON-encoded as a JS string literal — wrapping the whole object in quotes and escaping it.

## Fix

Return `template.JS` from `ToJSON()`, which `html/template` trusts in the JS context and emits verbatim. Added a regression test that renders the manpage template and asserts the ld+json is a bare object rather than a quoted string.

Fixes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)