### PR TITLE
Fix Path Traversal vulnerability in minisrv using filepath.Rel verification

### DIFF
--- a/cmd/debiman-minisrv/minisrv.go
+++ b/cmd/debiman-minisrv/minisrv.go
@@ -38,10 +38,33 @@ var fileNotFound = errors.New("File not found")
 
 func serveFile(w http.ResponseWriter, r *http.Request) error {
 	compressed := false
-	path := filepath.Join(*servingDir, r.URL.Path)
+
+	// 1. Rendiamo assoluto e pulito il percorso base
+	baseDir, err := filepath.Abs(*servingDir)
+	if err != nil {
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return nil
+	}
+
+	// 2. Uniamo i percorsi e rendiamo assoluto il target
+	targetPath := filepath.Join(baseDir, r.URL.Path)
+	path, err := filepath.Abs(targetPath)
+	if err != nil {
+		http.Error(w, "Bad Request", http.StatusBadRequest)
+		return nil
+	}
+
+	// 3. Verifichiamo il prefisso (Evitiamo il Path Traversal)
+	rel, err := filepath.Rel(baseDir, path)
+	if err != nil || strings.HasPrefix(rel, "..") {
+		http.Error(w, "Forbidden", http.StatusForbidden)
+		return nil
+	}
+
 	if r.URL.Path == "/" {
 		path = filepath.Join(path, "index.html")
 	}
+
 	f, err := os.Open(path)
 	if err != nil {
 		if os.IsNotExist(err) {


### PR DESCRIPTION
### Description
This PR addresses a Path Traversal vulnerability in `debiman-minisrv` where unsanitized input from `r.URL.Path` was being passed directly into file operations.

Previously, the code relied on `filepath.Join(*servingDir, r.URL.Path)`. While `filepath.Join` calls `filepath.Clean` internally, it does not prevent directory traversal if the resulting path breaks out of the intended root directory (e.g., using payloads like `../../etc/passwd`).

### Changes
- Implemented absolute path resolution for both the base directory (`*servingDir`) and the target file path using `filepath.Abs`.
- Added a strict prefix validation check using `filepath.Rel`. By verifying that the relative path between the base directory and the target path does not start with `..`, we guarantee that the requested file strictly resides within the allowed serving directory.
- Safely handled input validation errors by returning a standard `403 Forbidden` HTTP status code when a traversal attempt is detected.

This mitigates arbitrary file read risks without breaking the existing static serving functionality.